### PR TITLE
fix act-1447

### DIFF
--- a/org.activiti.designer.export.bpmn20/src/main/java/org/activiti/designer/export/bpmn20/export/BoundaryEventExport.java
+++ b/org.activiti.designer.export.bpmn20/src/main/java/org/activiti/designer/export/bpmn20/export/BoundaryEventExport.java
@@ -40,11 +40,12 @@ public class BoundaryEventExport implements ActivitiNamespaceConstants {
       if (boundaryEvent.getName() != null) {
         xtw.writeAttribute("name", boundaryEvent.getName());
       }
-      if (boundaryEvent.isCancelActivity()) {
-      	xtw.writeAttribute("cancelActivity", "true");
-      } else {
-      	xtw.writeAttribute("cancelActivity", "false");
-      }
+      if (!(eventDefinitionList.get(0) instanceof ErrorEventDefinition))
+        if (boundaryEvent.isCancelActivity()) {
+        	xtw.writeAttribute("cancelActivity", "true");
+        } else {
+        	xtw.writeAttribute("cancelActivity", "false");
+        }
       
       if (boundaryEvent.getAttachedToRef() != null) {
         xtw.writeAttribute("attachedToRef", boundaryEvent.getAttachedToRef().getId());

--- a/org.activiti.designer.gui/src/main/java/org/activiti/designer/property/PropertyBoundaryErrorSection.java
+++ b/org.activiti.designer.gui/src/main/java/org/activiti/designer/property/PropertyBoundaryErrorSection.java
@@ -27,7 +27,6 @@ import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetWidgetFactory;
 
 public class PropertyBoundaryErrorSection extends ActivitiPropertySection implements ITabbedPropertyConstants {
 
-	private CCombo cancelActivityCombo;
 	private List<String> cancelFormats = Arrays.asList("true", "false");
 	private Text errorCodeText;
 
@@ -39,22 +38,12 @@ public class PropertyBoundaryErrorSection extends ActivitiPropertySection implem
 		Composite composite = factory.createFlatFormComposite(parent);
 		FormData data;
 		
-		cancelActivityCombo = factory.createCCombo(composite, SWT.NONE);
-		cancelActivityCombo.setItems((String[]) cancelFormats.toArray());
-		data = new FormData();
-		data.left = new FormAttachment(0, 160);
-		data.right = new FormAttachment(100, 0);
-		data.top = new FormAttachment(0, VSPACE);
-		cancelActivityCombo.setLayoutData(data);
-		cancelActivityCombo.addFocusListener(listener);
-		
-		createLabel(composite, "Cancel activity", cancelActivityCombo, factory); //$NON-NLS-1$
 
 		errorCodeText = factory.createText(composite, ""); //$NON-NLS-1$
 		data = new FormData();
 		data.left = new FormAttachment(0, 160);
-		data.right = new FormAttachment(100, -HSPACE);
-		data.top = new FormAttachment(cancelActivityCombo, VSPACE);
+		data.right = new FormAttachment(100, 0);
+		data.top = new FormAttachment(0, VSPACE);
 		errorCodeText.setLayoutData(data);
 		errorCodeText.addFocusListener(listener);
 
@@ -63,7 +52,6 @@ public class PropertyBoundaryErrorSection extends ActivitiPropertySection implem
 
 	@Override
 	public void refresh() {
-		cancelActivityCombo.removeFocusListener(listener);
 	  errorCodeText.removeFocusListener(listener);
 
 		PictogramElement pe = getSelectedPictogramElement();
@@ -71,13 +59,6 @@ public class PropertyBoundaryErrorSection extends ActivitiPropertySection implem
 			Object bo = getBusinessObject(pe);
 			if (bo == null)
 				return;
-			
-			boolean cancelActivity = ((BoundaryEvent) bo).isCancelActivity();
-			if(cancelActivity == false) {
-				cancelActivityCombo.select(1);
-			} else {
-				cancelActivityCombo.select(0);
-			}
 			
 			String errorCode = null;
 			if(bo instanceof BoundaryEvent) {
@@ -91,7 +72,6 @@ public class PropertyBoundaryErrorSection extends ActivitiPropertySection implem
 			}
 			errorCodeText.setText(errorCode == null ? "" : errorCode);
 		}
-		cancelActivityCombo.addFocusListener(listener);
 		errorCodeText.addFocusListener(listener);
 	}
 
@@ -114,12 +94,6 @@ public class PropertyBoundaryErrorSection extends ActivitiPropertySection implem
 							if(bo instanceof BoundaryEvent) {
   							BoundaryEvent boundaryEvent = (BoundaryEvent) bo;
   							
-  							int selection = cancelActivityCombo.getSelectionIndex();
-  							if(selection == 0) {
-  								boundaryEvent.setCancelActivity(true);
-  							} else {
-  								boundaryEvent.setCancelActivity(false);
-  							}
   							
   						  ErrorEventDefinition errorDefinition = (ErrorEventDefinition) boundaryEvent.getEventDefinitions().get(0);
   						  errorDefinition.setErrorCode(errorCode);


### PR DESCRIPTION
In designer, removes the cancelActivity property for error boundary event .
