### PR TITLE
 Fix the bug of changing the type of endEventType.

### DIFF
--- a/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/ChangeElementTypeFeature.java
+++ b/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/ChangeElementTypeFeature.java
@@ -85,6 +85,10 @@ public class ChangeElementTypeFeature extends AbstractCustomFeature {
 		createFeatureMap.put(EVENT_START_MESSAGE, new CreateMessageStartEventFeature(fp));
 		createFeatureMap.put(EVENT_START_ERROR, new CreateErrorStartEventFeature(fp));
 		
+    createFeatureMap.put(EVENT_END_NONE, new CreateEndEventFeature(fp));
+    createFeatureMap.put(EVENT_END_TERMINATE, new CreateTerminateEndEventFeature(fp));
+    createFeatureMap.put(EVENT_END_ERROR, new CreateErrorEndEventFeature(fp));
+    
 		createFeatureMap.put(EVENT_BOUNDARY_TIMER, new CreateBoundaryTimerFeature(fp));
     createFeatureMap.put(EVENT_BOUNDARY_ERROR, new CreateBoundaryErrorFeature(fp));
     createFeatureMap.put(EVENT_BOUNDARY_MESSAGE, new CreateBoundaryMessageFeature(fp));


### PR DESCRIPTION
 When using the designer to change the EndEventType, the expected element will not appear. According to the source code, the feature of creating EndEvent was not add to the Map.