### PR TITLE
ACT-2063 extended diagram wizard still uses Activiti constants

### DIFF
--- a/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/ui/wizard/diagram/CreateDefaultActivitiDiagramWizard.java
+++ b/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/ui/wizard/diagram/CreateDefaultActivitiDiagramWizard.java
@@ -155,7 +155,7 @@ public class CreateDefaultActivitiDiagramWizard extends BasicNewResourceWizard {
     return (CreateDefaultActivitiDiagramNameWizardPage) getPage(CreateDefaultActivitiDiagramNameWizardPage.PAGE_NAME);
   }
 
-  private String getDiagramName() {
+  protected String getDiagramName() {
     return getNamePage().getDiagramName();
   }
 

--- a/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/ui/wizard/project/CreateDefaultActivitiProjectWizard.java
+++ b/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/ui/wizard/project/CreateDefaultActivitiProjectWizard.java
@@ -124,7 +124,14 @@ public class CreateDefaultActivitiProjectWizard extends BasicNewProjectResourceW
 
   @Override
   public void setWindowTitle(final String newTitle) {
-    super.setWindowTitle("New Activiti Project");
+    if (null == newTitle || "".equals(newTitle))
+    {
+      super.setWindowTitle("New Activiti Project");
+    }
+    else
+    {
+      super.setWindowTitle(newTitle);
+    }
   }
 
   /**


### PR DESCRIPTION
Related to ACT-2023

The CreateDefaultActivitiProjectWizard setWIndowTitle() method had
hard-coded Activiti constant.

Missed a method that requires updated visibility (private to protected)
to rebrand/repackage. The CreateDefaultActivitiDiagramWizard method
getDiagramName() should be protected. The 

Found while testing recent resolved issue ACT-1964.