### PR TITLE
Annotation to load combobox items from a external file datasource

### DIFF
--- a/org.activiti.designer.integration/src/main/java/org/activiti/designer/integration/servicetask/annotation/PropertyItemsDataSource.java
+++ b/org.activiti.designer.integration/src/main/java/org/activiti/designer/integration/servicetask/annotation/PropertyItemsDataSource.java
@@ -9,20 +9,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * @author Tiese Barrell
+ * @author André Macedo
  * @version 1
- * @since 0.7.0
+ * @since 5.16.0
  * 
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
-public @interface PropertyItems {
-
-  public static final String[] DEFAULT_VALUE = new String[] {};
-
-  /**
-   * The items.
-   */
-  abstract String[] value();
-
+public @interface PropertyItemsDataSource {
+	abstract String filename();
 }


### PR DESCRIPTION
Hi,

I build a new annotation which make possible to load combobox property items from a datasource (at this moment only filebased is support, but it's easy to provide new ways). With annotation it's now possible to load values on the combobox wich depends of some external sources. Here is an example:

@Property(type = PropertyType.COMBOBOX_CHOICE, displayName = "Destination Device", required = true)
    @Help(displayHelpShort = "Destination Device", displayHelpLong = "The name of the destination device to transfer the file.")
    @PropertyItems({ "OLD 1", "OLD 2" })
    @PropertyItemsDataSource(filename="D:/valueList.txt")
    private String destinationDevice;

Any interest in include this in the designer source code?

Regards,

André Macedo.
