### PR TITLE
Fix the creation of int type data objects

### DIFF
--- a/org.activiti.designer.gui/src/main/java/org/activiti/designer/property/ui/DataPropertyEditor.java
+++ b/org.activiti.designer.gui/src/main/java/org/activiti/designer/property/ui/DataPropertyEditor.java
@@ -222,7 +222,7 @@ public class DataPropertyEditor extends TableFieldEditor {
 	private ValuedDataObject getDataObject(String type) {
 	    if (type.equals("string")) {
 	        return new StringDataObject();
-	      } else if (type.equals("integer")) {
+	      } else if (type.equals("int")) {
 	       return new IntegerDataObject();
 	      } else if (type.equals("long")) {
 	    	  return new LongDataObject();


### PR DESCRIPTION
The constant being checked when creating a new 'int' data object was 'integer' instead of 'int'.  This fixes the ACT-2195 Jira issue.