### PR TITLE
ACT-2016 Add multipane editor feature to Designer

### DIFF
--- a/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/editor/ActivitiDiagramEditorInput.java
+++ b/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/editor/ActivitiDiagramEditorInput.java
@@ -1,5 +1,6 @@
 package org.activiti.designer.eclipse.editor;
 
+import org.activiti.bpmn.model.SubProcess;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.graphiti.ui.editor.DiagramEditorInput;
@@ -8,6 +9,8 @@ public class ActivitiDiagramEditorInput extends DiagramEditorInput {
 
   private IFile diagramFile;
   private IFile dataFile;
+  private ActivitiDiagramEditor parentEditor;
+  private SubProcess subprocess;
 
   public ActivitiDiagramEditorInput(URI diagramUri, String providerId) {
     super(diagramUri, providerId);
@@ -27,6 +30,22 @@ public class ActivitiDiagramEditorInput extends DiagramEditorInput {
 
   public void setDataFile(IFile dataFileName) {
     this.dataFile = dataFileName;
+  }
+
+  public ActivitiDiagramEditor getParentEditor() {
+    return parentEditor;
+  }
+
+  public void setParentEditor(ActivitiDiagramEditor parentEditor) {
+    this.parentEditor = parentEditor;
+  }
+
+  public SubProcess getSubprocess() {
+    return subprocess;
+  }
+
+  public void setSubprocess(SubProcess subprocess) {
+    this.subprocess = subprocess;
   }
 
   @Override

--- a/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/editor/GraphitiToBpmnDI.java
+++ b/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/editor/GraphitiToBpmnDI.java
@@ -18,7 +18,10 @@ import org.activiti.bpmn.model.Pool;
 import org.activiti.bpmn.model.Process;
 import org.activiti.bpmn.model.SequenceFlow;
 import org.activiti.bpmn.model.SubProcess;
+import org.activiti.designer.eclipse.common.ActivitiPlugin;
 import org.activiti.designer.util.editor.BpmnMemoryModel;
+import org.activiti.designer.util.preferences.Preferences;
+import org.activiti.designer.util.preferences.PreferencesUtil;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.graphiti.datatypes.ILocation;
@@ -153,7 +156,8 @@ public class GraphitiToBpmnDI {
           updateSequenceFlow((SequenceFlow) element);
         } else if (element instanceof FlowElement) {
           updateFlowElement(element);
-          if (element instanceof SubProcess) {
+          if (!PreferencesUtil.getBooleanPreference(Preferences.EDITOR_ENABLE_MULTI_DIAGRAM, ActivitiPlugin.getDefault()) 
+              && element instanceof SubProcess) {
             SubProcess subProcess = (SubProcess) element;
             loopThroughElements(subProcess.getFlowElements(), subProcess);
             loopThroughElements(subProcess.getArtifacts(), subProcess);

--- a/org.activiti.designer.gui/src/main/java/org/activiti/designer/controller/SubProcessShapeController.java
+++ b/org.activiti.designer.gui/src/main/java/org/activiti/designer/controller/SubProcessShapeController.java
@@ -12,6 +12,8 @@ import org.activiti.designer.util.bpmn.BpmnExtensionUtil;
 import org.activiti.designer.util.eclipse.ActivitiUiUtil;
 import org.activiti.designer.util.platform.OSEnum;
 import org.activiti.designer.util.platform.OSUtil;
+import org.activiti.designer.util.preferences.Preferences;
+import org.activiti.designer.util.preferences.PreferencesUtil;
 import org.activiti.designer.util.style.StyleUtil;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.graphiti.features.IDirectEditingInfo;
@@ -66,10 +68,17 @@ public class SubProcessShapeController extends AbstractBusinessObjectShapeContro
     Diagram diagram = getFeatureProvider().getDiagramTypeProvider().getDiagram();
     final SubProcess addedSubProcess = (SubProcess) businessObject;
     
+    boolean enableMultiDiagram = PreferencesUtil.getBooleanPreference(Preferences.EDITOR_ENABLE_MULTI_DIAGRAM, ActivitiPlugin.getDefault());
+
     // check whether the context has a size (e.g. from a create feature)
     // otherwise define a default size for the shape
-    width = width <= 0 ? 205 : width;
-    height = height <= 0 ? 205 : height;
+    if (!enableMultiDiagram) {
+      width = width <= 0 ? 205 : width;
+      height = height <= 0 ? 205 : height;
+    } else {
+      width = width <= 0 ? 105 : width;
+      height = height <= 0 ? 55 : height;
+    }
 
     // create invisible outer rectangle expanded by
     // the width needed for the anchor
@@ -135,7 +144,13 @@ public class SubProcessShapeController extends AbstractBusinessObjectShapeContro
     // direct editing shall be opened after object creation
     directEditingInfo.setPictogramElement(shape);
     directEditingInfo.setGraphicsAlgorithm(text);
-    
+
+    if (enableMultiDiagram) {
+      final Shape expandShape = peCreateService.createShape(containerShape, false);
+      Image expandImage = gaService.createImage(expandShape, PluginImage.IMG_SUBPROCESS_EXPANDED.getImageKey());
+      gaService.setLocationAndSize(expandImage, (width - IMAGE_SIZE) / 2, (height - IMAGE_SIZE) - 2, IMAGE_SIZE, IMAGE_SIZE);
+    }
+
     // add a chopbox anchor to the shape
     peCreateService.createChopboxAnchor(containerShape);
 

--- a/org.activiti.designer.gui/src/main/java/org/activiti/designer/diagram/ActivitiToolBehaviorProvider.java
+++ b/org.activiti.designer.gui/src/main/java/org/activiti/designer/diagram/ActivitiToolBehaviorProvider.java
@@ -89,6 +89,7 @@ import org.activiti.designer.features.CreateTimerStartEventFeature;
 import org.activiti.designer.features.CreateTransactionFeature;
 import org.activiti.designer.features.CreateUserTaskFeature;
 import org.activiti.designer.features.DeletePoolFeature;
+import org.activiti.designer.features.OpenSubProcessEditorFeature;
 import org.activiti.designer.features.contextmenu.OpenCalledElementForCallActivity;
 import org.activiti.designer.integration.annotation.TaskName;
 import org.activiti.designer.integration.annotation.TaskNames;
@@ -201,12 +202,13 @@ public class ActivitiToolBehaviorProvider extends DefaultToolBehaviorProvider {
 
   @Override
   public ICustomFeature getDoubleClickFeature(IDoubleClickContext context) {
-    /*
-     * ICustomFeature customFeature = new
-     * ExpandCollapseSubProcessFeature(getFeatureProvider()); if
-     * (customFeature.canExecute(context)) { return customFeature; }
-     */
-    
+    if (PreferencesUtil.getBooleanPreference(Preferences.EDITOR_ENABLE_MULTI_DIAGRAM, ActivitiPlugin.getDefault())) {
+      ICustomFeature customFeature = new OpenSubProcessEditorFeature(getFeatureProvider());
+      if (customFeature.canExecute(context)) {
+        return customFeature;
+      }
+    }
+
     //open call activity called element
     openCallActivityCalledElement(context);
     
@@ -1008,34 +1010,6 @@ public class ActivitiToolBehaviorProvider extends DefaultToolBehaviorProvider {
     }
   }
 
-  private boolean subProcessDiagramExists(SubProcess subProcess) {
-    Resource resource = getDiagramTypeProvider().getDiagram().eResource();
-
-    URI uri = resource.getURI();
-    URI uriTrimmed = uri.trimFragment();
-
-    if (uriTrimmed.isPlatformResource()) {
-
-      String platformString = uriTrimmed.toPlatformString(true);
-
-      IResource fileResource = ResourcesPlugin.getWorkspace().getRoot().findMember(platformString);
-
-      if (fileResource != null) {
-        IProject project = fileResource.getProject();
-        final String parentDiagramName = uriTrimmed.trimFileExtension().lastSegment();
-
-        IFile file = project.getFile(String.format(ActivitiConstants.DIAGRAM_FOLDER + "%s.%s" + ActivitiConstants.DATA_FILE_EXTENSION,
-                parentDiagramName, subProcess.getId()));
-
-        Diagram diagram = GraphitiUiInternal.getEmfService().getDiagramFromFile(file, new ResourceSetImpl());
-
-        return diagram != null;
-      }
-    }
-    // Safe default assumption
-    return true;
-  }
-  
   //method for open call activity called element
   public void openCallActivityCalledElement(ICustomContext context) {
     if (context.getPictogramElements() != null) {

--- a/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/AbstractCreateBPMNConnectionFeature.java
+++ b/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/AbstractCreateBPMNConnectionFeature.java
@@ -1,12 +1,15 @@
-/**
- * 
- */
 package org.activiti.designer.features;
 
 import org.activiti.bpmn.model.BaseElement;
+import org.activiti.designer.eclipse.common.ActivitiPlugin;
+import org.activiti.designer.eclipse.editor.ActivitiDiagramEditor;
+import org.activiti.designer.eclipse.editor.ActivitiDiagramEditorInput;
 import org.activiti.designer.util.eclipse.ActivitiUiUtil;
+import org.activiti.designer.util.preferences.Preferences;
+import org.activiti.designer.util.preferences.PreferencesUtil;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.eclipse.graphiti.features.impl.AbstractCreateConnectionFeature;
+import org.eclipse.graphiti.mm.pictograms.Diagram;
 
 /**
  * @author Tiese Barrell
@@ -25,7 +28,25 @@ public abstract class AbstractCreateBPMNConnectionFeature extends AbstractCreate
   protected abstract Class<? extends BaseElement> getFeatureClass();
 
   protected String getNextId() {
-    return ActivitiUiUtil.getNextId(getFeatureClass(), getFeatureIdKey(), getDiagram());
+    if (!PreferencesUtil.getBooleanPreference(Preferences.EDITOR_ENABLE_MULTI_DIAGRAM, ActivitiPlugin.getDefault())) {
+      return ActivitiUiUtil.getNextId(getFeatureClass(), getFeatureIdKey(), getDiagram());
+    } else {
+      return ActivitiUiUtil.getNextId(getFeatureClass(), getFeatureIdKey(), getTopLevelDiagram());
+    }
+  }
+
+  private Diagram getTopLevelDiagram()
+  {
+    ActivitiDiagramEditor editor = (ActivitiDiagramEditor)getDiagramBehavior().getDiagramContainer();
+    ActivitiDiagramEditorInput adei=(ActivitiDiagramEditorInput)editor.getDiagramEditorInput();
+    ActivitiDiagramEditor parent= adei.getParentEditor();
+    while (parent!=null)
+    {
+      editor=parent;
+      adei=(ActivitiDiagramEditorInput)parent.getDiagramEditorInput();
+      parent =adei.getParentEditor();
+    }
+    return editor.getDiagramTypeProvider().getDiagram();
   }
 
 }

--- a/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/CreatePoolFeature.java
+++ b/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/CreatePoolFeature.java
@@ -4,8 +4,13 @@ import org.activiti.bpmn.model.Lane;
 import org.activiti.bpmn.model.Pool;
 import org.activiti.bpmn.model.Process;
 import org.activiti.designer.PluginImage;
+import org.activiti.designer.eclipse.common.ActivitiPlugin;
+import org.activiti.designer.eclipse.editor.ActivitiDiagramEditor;
+import org.activiti.designer.eclipse.editor.ActivitiDiagramEditorInput;
 import org.activiti.designer.util.editor.BpmnMemoryModel;
 import org.activiti.designer.util.editor.ModelHandler;
+import org.activiti.designer.util.preferences.Preferences;
+import org.activiti.designer.util.preferences.PreferencesUtil;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.graphiti.features.IAddFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
@@ -26,10 +31,21 @@ public class CreatePoolFeature extends AbstractCreateBPMNFeature {
 
   @Override
   public boolean canCreate(ICreateContext context) {
-    if (context.getTargetContainer() instanceof Diagram)
+    if (context.getTargetContainer() instanceof Diagram && !isInSubprocessEditor()) {
       return true;
+    } else{
+      return false;
+    }
+  }
 
-    return false;
+  private boolean isInSubprocessEditor() {
+    if (PreferencesUtil.getBooleanPreference(Preferences.EDITOR_ENABLE_MULTI_DIAGRAM, ActivitiPlugin.getDefault())) {
+      ActivitiDiagramEditor ade = (ActivitiDiagramEditor)getDiagramBehavior().getDiagramContainer();
+      ActivitiDiagramEditorInput adei = (ActivitiDiagramEditorInput)ade.getDiagramEditorInput();
+      return adei.getParentEditor() != null;
+    } else {
+      return false;
+    }
   }
 
   @Override

--- a/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/CreateSequenceFlowFeature.java
+++ b/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/CreateSequenceFlowFeature.java
@@ -14,6 +14,8 @@ import org.activiti.bpmn.model.StartEvent;
 import org.activiti.bpmn.model.SubProcess;
 import org.activiti.designer.PluginImage;
 import org.activiti.designer.eclipse.common.ActivitiPlugin;
+import org.activiti.designer.eclipse.editor.ActivitiDiagramEditor;
+import org.activiti.designer.eclipse.editor.ActivitiDiagramEditorInput;
 import org.activiti.designer.util.editor.ModelHandler;
 import org.activiti.designer.util.preferences.Preferences;
 import org.activiti.designer.util.preferences.PreferencesUtil;
@@ -125,6 +127,7 @@ public class CreateSequenceFlowFeature extends AbstractCreateBPMNConnectionFeatu
    */
   protected SequenceFlow createSequenceFlow(FlowNode source, FlowNode target, ICreateConnectionContext context) {
     SequenceFlow sequenceFlow = new SequenceFlow();
+    boolean enableMultiDiagram = PreferencesUtil.getBooleanPreference(Preferences.EDITOR_ENABLE_MULTI_DIAGRAM, ActivitiPlugin.getDefault());
 
     sequenceFlow.setId(getNextId());
     sequenceFlow.setSourceRef(source.getId());
@@ -151,6 +154,15 @@ public class CreateSequenceFlowFeature extends AbstractCreateBPMNConnectionFeatu
     if (parentContainer instanceof Diagram) {
       ModelHandler.getModel(EcoreUtil.getURI(getDiagram())).getBpmnModel().getMainProcess().addFlowElement(sequenceFlow);
 
+      if (enableMultiDiagram) {
+        ActivitiDiagramEditor editor = (ActivitiDiagramEditor)getDiagramBehavior().getDiagramContainer();
+        ActivitiDiagramEditorInput adei=(ActivitiDiagramEditorInput)editor.getDiagramEditorInput();
+        if (adei.getSubprocess()!=null)
+        {
+          final SubProcess subProcess = (SubProcess)adei.getSubprocess();
+          subProcess.addFlowElement(sequenceFlow);
+        }
+      }
     } else {
       Object parentObject = getBusinessObjectForPictogramElement(parentContainer);
       if (parentObject instanceof SubProcess) {

--- a/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/OpenSubProcessEditorFeature.java
+++ b/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/OpenSubProcessEditorFeature.java
@@ -1,0 +1,293 @@
+package org.activiti.designer.features;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.activiti.bpmn.converter.BpmnXMLConverter;
+import org.activiti.bpmn.model.Artifact;
+import org.activiti.bpmn.model.Association;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.bpmn.model.GraphicInfo;
+import org.activiti.bpmn.model.Process;
+import org.activiti.bpmn.model.SequenceFlow;
+import org.activiti.bpmn.model.StartEvent;
+import org.activiti.bpmn.model.SubProcess;
+import org.activiti.bpmn.model.ValuedDataObject;
+import org.activiti.designer.eclipse.common.ActivitiPlugin;
+import org.activiti.designer.eclipse.editor.ActivitiDiagramEditor;
+import org.activiti.designer.eclipse.editor.ActivitiDiagramEditorInput;
+import org.activiti.designer.eclipse.util.FileService;
+import org.activiti.designer.eclipse.util.Util;
+import org.activiti.designer.util.ActivitiConstants;
+import org.activiti.designer.util.eclipse.ActivitiUiUtil;
+import org.activiti.designer.util.editor.BpmnMemoryModel;
+import org.activiti.designer.util.editor.ModelHandler;
+import org.activiti.designer.util.preferences.Preferences;
+import org.activiti.designer.util.preferences.PreferencesUtil;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.emf.transaction.TransactionalEditingDomain;
+import org.eclipse.graphiti.features.IFeatureProvider;
+import org.eclipse.graphiti.features.context.ICustomContext;
+import org.eclipse.graphiti.mm.pictograms.Diagram;
+import org.eclipse.graphiti.mm.pictograms.PictogramElement;
+import org.eclipse.graphiti.services.Graphiti;
+import org.eclipse.graphiti.ui.features.AbstractDrillDownFeature;
+import org.eclipse.graphiti.ui.internal.services.GraphitiUiInternal;
+import org.eclipse.graphiti.ui.services.GraphitiUi;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.IDE;
+
+@SuppressWarnings("restriction")
+public class OpenSubProcessEditorFeature extends AbstractDrillDownFeature {
+  SubProcess subprocess;
+  IFile dataFile;
+  IFile diagramFile;
+
+  public OpenSubProcessEditorFeature(IFeatureProvider fp) {
+    super(fp);
+  }
+
+  @Override
+  public String getName() {
+    return "Open Sub Process Editor"; //$NON-NLS-1$
+  }
+
+  @Override
+  public String getDescription() {
+    return "Expand or collapse the sub process"; //$NON-NLS-1$
+  }
+
+  @Override
+  public boolean canExecute(ICustomContext context) {
+    if (null != context.getPictogramElements() && context.getPictogramElements().length > 0) {
+      Object bo = getBusinessObjectForPictogramElement(context.getPictogramElements()[0]);
+      return SubProcess.class.equals(bo.getClass());
+    }
+    return false;
+  }
+
+  @Override
+  public void execute(ICustomContext context) {
+    try {
+      subprocess = (SubProcess) getBusinessObjectForPictogramElement(context.getPictogramElements()[0]);
+      initFiles4Subprocess();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    super.execute(context);
+  }
+
+  private void initFiles4Subprocess() {
+    Resource resource = getDiagram().eResource();
+
+    URI uri = resource.getURI();
+    URI uriTrimmed = uri.trimFragment();
+
+    IPath path = new Path(String.format(
+        uriTrimmed.trimFileExtension().toPlatformString(true) + ".%s" + ActivitiConstants.DATA_FILE_EXTENSION,
+        subprocess.getId()));
+    dataFile = ResourcesPlugin.getWorkspace().getRoot().getFile(path);
+    diagramFile = ResourcesPlugin.getWorkspace().getRoot()
+        .getFile(new Path(Util.getSubProcessURI(getDiagram(), subprocess.getId()).toPlatformString(true)));
+    if (!dataFile.exists())
+      saveSubprocessElements();
+  }
+
+  private Diagram getTopLevelDiagram() {
+    ActivitiDiagramEditor editor = (ActivitiDiagramEditor) getDiagramBehavior().getDiagramContainer();
+    ActivitiDiagramEditorInput adei = (ActivitiDiagramEditorInput) editor.getDiagramEditorInput();
+    ActivitiDiagramEditor parent = adei.getParentEditor();
+    while (parent != null) {
+      editor = parent;
+      adei = (ActivitiDiagramEditorInput) parent.getDiagramEditorInput();
+      parent = adei.getParentEditor();
+    }
+    return editor.getDiagramTypeProvider().getDiagram();
+  }
+
+  private void saveSubprocessElements() {
+    BpmnMemoryModel model = new BpmnMemoryModel(getFeatureProvider(), dataFile);
+    BpmnModel bpmnModel = new BpmnModel();
+    Process process = new Process();
+    process.setName(subprocess.getName());
+    process.setId(subprocess.getId());
+
+    BpmnModel pMmodel = ModelHandler.getModel(EcoreUtil.getURI(getDiagram())).getBpmnModel();
+
+    process.getFlowElements().addAll(subprocess.getFlowElements());
+    if (process.getFlowElements().isEmpty()) // init with a start event, as
+                                             // empty process will be ignored
+    {
+      StartEvent start = new StartEvent();
+      start.setId(
+          ActivitiUiUtil.getNextId(StartEvent.class, CreateStartEventFeature.FEATURE_ID_KEY, getTopLevelDiagram()));
+      start.setName("Start");
+      process.addFlowElement(start);
+      GraphicInfo gi = new GraphicInfo();
+      gi.setHeight(35);
+      gi.setWidth(35);
+      gi.setX(10);
+      gi.setY(10);
+      gi.setElement(start);
+      bpmnModel.addGraphicInfo(start.getId(), gi);
+      subprocess.addFlowElement(start);
+      pMmodel.addGraphicInfo(start.getId(), gi);
+    } else {
+      if (pMmodel.getLocationMap().size() > 0) {
+        for (FlowElement element : process.getFlowElements()) {
+          if (element instanceof SequenceFlow) {
+            bpmnModel.addFlowGraphicInfoList(element.getId(), pMmodel.getFlowLocationGraphicInfo(element.getId()));
+            continue;
+          } else if (ValuedDataObject.class.isAssignableFrom(element.getClass())) {
+            continue;
+          } else if (element instanceof SubProcess) {
+            // loop
+          }
+          bpmnModel.addGraphicInfo(element.getId(), pMmodel.getGraphicInfo(element.getId()));
+        }
+      }
+    }
+
+    process.getArtifacts().addAll(subprocess.getArtifacts());
+    if (pMmodel.getLocationMap().size() > 0) {
+      for (Artifact element : process.getArtifacts()) {
+        if (element instanceof Association) {
+          bpmnModel.addFlowGraphicInfoList(element.getId(), pMmodel.getFlowLocationGraphicInfo(element.getId()));
+          continue;
+        }
+        bpmnModel.addGraphicInfo(element.getId(), pMmodel.getGraphicInfo(element.getId()));
+      }
+    }
+
+    bpmnModel.addProcess(process);
+    model.setBpmnModel(bpmnModel);
+    String dataFileString = dataFile.getLocationURI().getPath();
+    try {
+      BpmnXMLConverter converter = new BpmnXMLConverter();
+
+      byte[] xmlBytes = converter.convertToXML(model.getBpmnModel());
+
+      File objectsFile = new File(dataFileString);
+      FileOutputStream fos = new FileOutputStream(objectsFile);
+      fos.write(xmlBytes);
+      fos.close();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  protected void openDiagramEditor(Diagram diagram) {
+    final String providerId = GraphitiUi.getExtensionManager().getDiagramTypeProviderId(diagram.getDiagramTypeId());
+    final ActivitiDiagramEditorInput result = new ActivitiDiagramEditorInput(EcoreUtil.getURI(diagram), providerId);
+    final ActivitiDiagramEditor diagramEditor = (ActivitiDiagramEditor) getFeatureProvider().getDiagramTypeProvider()
+        .getDiagramBehavior().getDiagramContainer();
+    result.setDiagramFile(diagramFile);
+    result.setDataFile(dataFile);
+    result.setParentEditor(diagramEditor);
+    result.setSubprocess(subprocess);
+    final IWorkbench workbench = PlatformUI.getWorkbench();
+
+    workbench.getDisplay().syncExec(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          IDE.openEditor(workbench.getActiveWorkbenchWindow().getActivePage(), result,
+              ActivitiConstants.DIAGRAM_EDITOR_ID);
+        } catch (PartInitException exception) {
+          exception.printStackTrace();
+        }
+      }
+    });
+  }
+
+  @Override
+  protected Collection<Diagram> getLinkedDiagrams(PictogramElement pe) {
+    return getDiagrams();
+  }
+
+  @Override
+  protected Collection<Diagram> getDiagrams() {
+
+    Collection<Diagram> result = new ArrayList<Diagram>();
+    Resource resource = getDiagram().eResource();
+
+    URI uri = resource.getURI();
+    URI uriTrimmed = uri.trimFragment();
+
+    if (uriTrimmed.isPlatformResource()) {
+
+      String platformString = uriTrimmed.toPlatformString(true);
+
+      IResource fileResource = ResourcesPlugin.getWorkspace().getRoot().findMember(platformString);
+
+      if (fileResource != null) {
+        IProject project = fileResource.getProject();
+
+        if (diagramFile.exists()) {
+          result.add(getExistingDiagram(project, diagramFile));
+        } else {
+          result.add(getNewDiagram(project, diagramFile));
+        }
+      }
+    }
+
+    return result;
+  }
+
+  private Diagram getNewDiagram(final IProject project, final IFile targetFile) {
+    Diagram diagram = null;
+    URI uri = URI.createPlatformResourceURI(targetFile.getFullPath().toString(), true);
+
+    TransactionalEditingDomain domain = null;
+
+    boolean createContent = PreferencesUtil.getBooleanPreference(Preferences.EDITOR_ADD_DEFAULT_CONTENT_TO_DIAGRAMS,
+        ActivitiPlugin.getDefault());
+
+    final ActivitiDiagramEditor diagramEditor = (ActivitiDiagramEditor) getFeatureProvider().getDiagramTypeProvider()
+        .getDiagramEditor();
+
+    if (createContent) {
+      final InputStream contentStream = Util.getContentStream(Util.Content.NEW_SUBPROCESS_CONTENT);
+      InputStream replacedStream = Util.swapStreamContents(subprocess.getName(), contentStream);
+      domain = FileService.createEmfFileForDiagram(uri, null, diagramEditor, replacedStream, targetFile);
+      diagram = org.eclipse.graphiti.ui.internal.services.GraphitiUiInternal.getEmfService()
+          .getDiagramFromFile(targetFile, domain.getResourceSet());
+    } else {
+      diagram = Graphiti.getPeCreateService().createDiagram("BPMNdiagram", subprocess.getId(), true);
+      ResourceSet resourceSet = new ResourceSetImpl();
+      final Resource resource = resourceSet.createResource(uri);
+      resource.getContents().add(diagram);
+      try {
+        resource.save(null);
+      } catch (IOException e1) {
+        e1.printStackTrace();
+      }
+    }
+
+    return diagram;
+  }
+
+  private Diagram getExistingDiagram(final IProject project, final IFile targetFile) {
+    final ResourceSet rSet = new ResourceSetImpl();
+    Diagram diagram = GraphitiUiInternal.getEmfService().getDiagramFromFile(targetFile, rSet);
+    return diagram;
+  }
+}

--- a/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/OpenSubProcessEditorFeature.java
+++ b/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/OpenSubProcessEditorFeature.java
@@ -209,8 +209,8 @@ public class OpenSubProcessEditorFeature extends AbstractDrillDownFeature {
       @Override
       public void run() {
         try {
-          IDE.openEditor(workbench.getActiveWorkbenchWindow().getActivePage(), result,
-              ActivitiConstants.DIAGRAM_EDITOR_ID);
+          ActivitiDiagramEditor childEditor = (ActivitiDiagramEditor)IDE.openEditor(workbench.getActiveWorkbenchWindow().getActivePage(), result, ActivitiConstants.DIAGRAM_EDITOR_ID);
+          diagramEditor.getChildEditors().add(childEditor);
         } catch (PartInitException exception) {
           exception.printStackTrace();
         }

--- a/org.activiti.designer.gui/src/main/java/org/activiti/designer/preferences/ActivitiEditorPreferencesPage.java
+++ b/org.activiti.designer.gui/src/main/java/org/activiti/designer/preferences/ActivitiEditorPreferencesPage.java
@@ -19,6 +19,8 @@ public class ActivitiEditorPreferencesPage extends FieldEditorPreferencePage imp
 				"&Automatically create a label when adding a new sequence flow", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(Preferences.EDITOR_ADD_DEFAULT_CONTENT_TO_DIAGRAMS.getPreferenceId(),
 				"&Create default diagram content when creating new diagrams and subprocesses", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(Preferences.EDITOR_ENABLE_MULTI_DIAGRAM.getPreferenceId(),
+				"&Enable multidiagram editing for subprocesses", getFieldEditorParent()));
 	}
 
 	@Override

--- a/org.activiti.designer.util/src/main/java/org/activiti/designer/util/preferences/Preferences.java
+++ b/org.activiti.designer.util/src/main/java/org/activiti/designer/util/preferences/Preferences.java
@@ -13,13 +13,13 @@ package org.activiti.designer.util.preferences;
  */
 public enum Preferences {
 
-  
   ECLIPSE_ACTIVITI_JAR_LOCATION("org.activiti.designer.preferences.eclipse.activitiJarLocation"),
   ALFRESCO_ENABLE("com.alfresco.designer.preferences.enable"),
   ALFRESCO_FORMTYPES_STARTEVENT("com.alfresco.designer.preferences.formtypes.startevent"),
   ALFRESCO_FORMTYPES_USERTASK("com.alfresco.designer.preferences.formtypes.usertask"),
   EDITOR_ADD_LABELS_TO_NEW_SEQUENCEFLOWS("org.activiti.designer.preferences.editor.addLabelsToNewSequenceFlows"), 
   EDITOR_ADD_DEFAULT_CONTENT_TO_DIAGRAMS("org.activiti.designer.preferences.editor.addDefaultContentToDiagrams"), 
+  EDITOR_ENABLE_MULTI_DIAGRAM("org.activiti.designer.preferences.editor.enableMultiDiagram"), 
   SAVE_TO_FORMAT("org.activiti.designer.preferences.save.saveToFormat"), 
   SAVE_IMAGE("org.activiti.designer.preferences.save.imageFormat"),
   SAVE_IMAGE_ADD_OVERLAY("org.activiti.designer.preferences.save.imageAddOverlay"),


### PR DESCRIPTION
Note that this feature can be enabled/disabled using an editor preference. If the editor preference setting changes from enabled to disabled, any BPMN DI information diagrams saved with it enabled should be regenerated by removing all BPMN DI info from the xml file which will trigger usage of the embedded autolayout function. I experimented with making the BpmnAutoLayout method for recalculating the subprocess graphic info, but it would require an update to make the  translateNestedSubprocesses method public. The subprocess element is not resized automatically, so the user would still have to resize it manually to "see" the contained child elements.

FYI - there were some mismatched CRLF issues with ActivitiToolBehaviorProvider.java, so some lines were not really changed.