### PR TITLE
fix:No process left in Model when last pool/lane deleted

### DIFF
--- a/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/editor/ActivitiDiagramEditor.java
+++ b/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/editor/ActivitiDiagramEditor.java
@@ -75,9 +75,7 @@ import org.apache.commons.lang.StringUtils;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.*;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.SWTGraphics;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -198,8 +196,13 @@ public class ActivitiDiagramEditor extends DiagramEditor {
       doInvokeExportMarshallers(model);
 
     } catch (Exception e) {
-      // TODO Auto-generated catch block
+      Status status=new Status(IStatus.ERROR, ActivitiPlugin.getDefault().getBundle().getSymbolicName(), "save failed!", e);
+      ActivitiPlugin.getDefault().getLog().log(status);
       e.printStackTrace();
+      MessageBox messageBox = new MessageBox(Display.getCurrent().getActiveShell(), SWT.ICON_WARNING | SWT.OK);
+      messageBox.setText("Warning");
+      messageBox.setMessage("Error while saving the model " + e.getLocalizedMessage());
+      messageBox.open();
     }
 
     ((BasicCommandStack) getEditingDomain().getCommandStack()).saveIsDone();

--- a/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/editor/ActivitiDiagramEditor.java
+++ b/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/editor/ActivitiDiagramEditor.java
@@ -215,6 +215,10 @@ public class ActivitiDiagramEditor extends DiagramEditor {
     final IFeatureProvider featureProvider = getDiagramTypeProvider().getFeatureProvider();
     new GraphitiToBpmnDI(model, featureProvider).processGraphitiElements();
 
+    MessageBox mb = new MessageBox(Display.getCurrent().getActiveShell(), SWT.ICON_WARNING | SWT.OK);
+    mb.setText("Warning");
+    mb.setMessage("model target name space"+    model.getBpmnModel().getTargetNamespace());
+    mb.open();
     BpmnXMLConverter converter = new BpmnXMLConverter();
     byte[] xmlBytes = converter.convertToXML(model.getBpmnModel());
 

--- a/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/editor/ActivitiDiagramEditor.java
+++ b/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/editor/ActivitiDiagramEditor.java
@@ -215,10 +215,6 @@ public class ActivitiDiagramEditor extends DiagramEditor {
     final IFeatureProvider featureProvider = getDiagramTypeProvider().getFeatureProvider();
     new GraphitiToBpmnDI(model, featureProvider).processGraphitiElements();
 
-    MessageBox mb = new MessageBox(Display.getCurrent().getActiveShell(), SWT.ICON_WARNING | SWT.OK);
-    mb.setText("Warning");
-    mb.setMessage("model target name space"+    model.getBpmnModel().getTargetNamespace());
-    mb.open();
     BpmnXMLConverter converter = new BpmnXMLConverter();
     byte[] xmlBytes = converter.convertToXML(model.getBpmnModel());
 

--- a/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/DeleteLaneFeature.java
+++ b/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/DeleteLaneFeature.java
@@ -87,7 +87,9 @@ public class DeleteLaneFeature extends DefaultDeleteFeature {
 		  
 		  if(laneProcess.getLanes().size() == 1) {
         Process process = model.getBpmnModel().getProcess(parentPool.getId());
-        model.getBpmnModel().getProcesses().remove(process);
+        if (model.getBpmnModel().getProcesses().size()>1) {
+              model.getBpmnModel().getProcesses().remove(process);
+        }
         model.getBpmnModel().getPools().remove(parentPool);
         PictogramElement poolElement = getFeatureProvider().getPictogramElementForBusinessObject(parentPool);
         IRemoveContext poolRc = new RemoveContext(poolElement);

--- a/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/DeletePoolFeature.java
+++ b/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/DeletePoolFeature.java
@@ -65,7 +65,9 @@ public class DeletePoolFeature extends AbstractCustomFeature {
         final Pool pool = (Pool) boObject;
         BpmnMemoryModel model = ModelHandler.getModel(EcoreUtil.getURI(getDiagram()));
         Process process = model.getBpmnModel().getProcess(pool.getId());
-        model.getBpmnModel().getProcesses().remove(process);
+        if (model.getBpmnModel().getProcesses().size()>1) {
+          model.getBpmnModel().getProcesses().remove(process);
+        }
         model.getBpmnModel().getPools().remove(pool);
         IRemoveContext rc = new RemoveContext(pictogramElement);
         IFeatureProvider featureProvider = getFeatureProvider();

--- a/org.activiti.designer.gui/src/main/java/org/activiti/designer/property/ui/MessageDefinitionEditor.java
+++ b/org.activiti.designer.gui/src/main/java/org/activiti/designer/property/ui/MessageDefinitionEditor.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.activiti.bpmn.model.*;
 import org.activiti.bpmn.model.Process;
+import org.activiti.designer.features.CreateMessageStartEventFeature;
 import org.activiti.designer.util.eclipse.ActivitiUiUtil;
 import org.activiti.designer.util.editor.BpmnMemoryModel;
 import org.activiti.designer.util.editor.ModelHandler;
@@ -189,8 +190,8 @@ public class MessageDefinitionEditor extends TableFieldEditor {
 
 
 	private void updateMessageRef(Message originalMessage, Message changedMessage, FlowElement element) {
-		if (element instanceof IntermediateCatchEvent) {
-            IntermediateCatchEvent event=(IntermediateCatchEvent)element;
+		if (element instanceof Event) {
+            Event event=(Event)element;
 			if (event.getEventDefinitions().get(0) != null) {
 				MessageEventDefinition eventDefinition = (MessageEventDefinition) event.getEventDefinitions().get(0);
 	            if (originalMessage.getId().equals(eventDefinition.getMessageRef())) {

--- a/org.activiti.designer.gui/src/main/java/org/activiti/designer/property/ui/MessageDefinitionEditor.java
+++ b/org.activiti.designer.gui/src/main/java/org/activiti/designer/property/ui/MessageDefinitionEditor.java
@@ -192,10 +192,12 @@ public class MessageDefinitionEditor extends TableFieldEditor {
 	private void updateMessageRef(Message originalMessage, Message changedMessage, FlowElement element) {
 		if (element instanceof Event) {
             Event event=(Event)element;
-			if (event.getEventDefinitions().get(0) != null) {
-				MessageEventDefinition eventDefinition = (MessageEventDefinition) event.getEventDefinitions().get(0);
-	            if (originalMessage.getId().equals(eventDefinition.getMessageRef())) {
-					eventDefinition.setMessageRef(changedMessage.getId());
+			for (EventDefinition eventDefinition:event.getEventDefinitions()) {
+				if (eventDefinition instanceof MessageEventDefinition)  {
+					MessageEventDefinition messageEventDefinition = (MessageEventDefinition)eventDefinition;
+					if (originalMessage.getId().equals(messageEventDefinition.getMessageRef())) {
+						messageEventDefinition.setMessageRef(changedMessage.getId());
+					}
 				}
 			}
 		}

--- a/org.activiti.designer.util/src/main/java/org/activiti/designer/util/editor/BpmnMemoryModel.java
+++ b/org.activiti.designer.util/src/main/java/org/activiti/designer/util/editor/BpmnMemoryModel.java
@@ -47,6 +47,7 @@ public class BpmnMemoryModel {
     process.setName("My process");
     process.setId("myProcess");
     bpmnModel.addProcess(process);
+    bpmnModel.setTargetNamespace("http://www.activiti.org/test");
     }
     
     public FlowElement getFlowElement(String ref) {


### PR DESCRIPTION
When there is only one pool in the model, if the pool or its last lane is deleted, its refrencing process is also deleted, and there will be no process left in the model, and no way to create a default one.

And this model can't be saved because it has NO process.

Look the model below, if we remove its pool, save it will get failed(The bpmn file wont get modified).

![snap2](https://cloud.githubusercontent.com/assets/8803140/18937982/c3a921e0-8627-11e6-8551-29d09d27fd68.jpg)
