### PR TITLE
code upgrade to compile with Eclipse Neon.2 (4.6.2)

### DIFF
--- a/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/editor/ActivitiDiagramEditor.java
+++ b/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/editor/ActivitiDiagramEditor.java
@@ -100,6 +100,7 @@ import org.eclipse.graphiti.mm.pictograms.ChopboxAnchor;
 import org.eclipse.graphiti.mm.pictograms.ContainerShape;
 import org.eclipse.graphiti.mm.pictograms.Diagram;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
+import org.eclipse.graphiti.ui.editor.DiagramBehavior;
 import org.eclipse.graphiti.ui.editor.DiagramEditor;
 import org.eclipse.graphiti.ui.editor.DiagramEditorInput;
 import org.eclipse.swt.SWT;
@@ -305,7 +306,7 @@ public class ActivitiDiagramEditor extends DiagramEditor {
 
   private void marshallImage(BpmnMemoryModel model, String modelFileName) {
     try {
-      final GraphicalViewer graphicalViewer = (GraphicalViewer) ((DiagramEditor) model.getFeatureProvider().getDiagramTypeProvider().getDiagramEditor())
+      final GraphicalViewer graphicalViewer = (GraphicalViewer) ((DiagramBehavior) model.getFeatureProvider().getDiagramTypeProvider().getDiagramBehavior())
               .getAdapter(GraphicalViewer.class);
 
       if (graphicalViewer == null || graphicalViewer.getEditPartRegistry() == null) {

--- a/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/editor/ActivitiEditorUpdateBehavior.java
+++ b/org.activiti.designer.eclipse/src/main/java/org/activiti/designer/eclipse/editor/ActivitiEditorUpdateBehavior.java
@@ -33,7 +33,7 @@ public class ActivitiEditorUpdateBehavior extends DefaultUpdateBehavior {
   @Override
   public TransactionalEditingDomain getEditingDomain() {
     if (super.getEditingDomain() == null) {
-      createEditingDomain();
+      createEditingDomain(null);
     }
 
     return super.getEditingDomain();

--- a/org.activiti.designer.feature/feature.xml
+++ b/org.activiti.designer.feature/feature.xml
@@ -62,7 +62,7 @@ This Agreement is governed by the laws of the State of New York and the intellec
 
    <includes
          id="org.eclipse.graphiti.feature"
-         version="0.11.4"/>
+         version="0.0.0"/>
 
    <requires>
       <import plugin="org.eclipse.ui"/>

--- a/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/ExpandCollapseSubProcessFeature.java
+++ b/org.activiti.designer.gui/src/main/java/org/activiti/designer/features/ExpandCollapseSubProcessFeature.java
@@ -128,7 +128,7 @@ public class ExpandCollapseSubProcessFeature extends AbstractDrillDownFeature {
 		    Preferences.EDITOR_ADD_DEFAULT_CONTENT_TO_DIAGRAMS, ActivitiPlugin.getDefault());
 
 		final ActivitiDiagramEditor diagramEditor
-		  = (ActivitiDiagramEditor) getFeatureProvider().getDiagramTypeProvider().getDiagramEditor();
+		  = (ActivitiDiagramEditor) getFeatureProvider().getDiagramTypeProvider().getDiagramBehavior().getDiagramContainer();
 
 		if (createContent) {
 			final InputStream contentStream = Util.getContentStream(Util.Content.NEW_SUBPROCESS_CONTENT);

--- a/org.activiti.designer.gui/src/main/java/org/activiti/designer/property/AbstractPropertyCustomTaskSection.java
+++ b/org.activiti.designer.gui/src/main/java/org/activiti/designer/property/AbstractPropertyCustomTaskSection.java
@@ -18,6 +18,7 @@ import org.activiti.bpmn.model.UserTask;
 import org.activiti.designer.util.eclipse.ActivitiUiUtil;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
+import org.eclipse.graphiti.ui.editor.DiagramBehavior;
 import org.eclipse.graphiti.ui.editor.DiagramEditor;
 
 public class AbstractPropertyCustomTaskSection extends BaseActivitiPropertySection {
@@ -27,8 +28,8 @@ public class AbstractPropertyCustomTaskSection extends BaseActivitiPropertySecti
     if (pe != null) {
       Object bo = getBusinessObject(pe);
       if (bo instanceof ServiceTask || bo instanceof UserTask) {
-        DiagramEditor diagramEditor = (DiagramEditor) getDiagramEditor();
-        TransactionalEditingDomain editingDomain = diagramEditor.getEditingDomain();
+        DiagramBehavior diagramBehavior = (DiagramBehavior) getDiagramTypeProvider().getDiagramBehavior();
+        TransactionalEditingDomain editingDomain = diagramBehavior.getEditingDomain();
         ActivitiUiUtil.runModelChange(runnable, editingDomain, "Model Update");
       }
     }

--- a/org.activiti.designer.kickstart.eclipse/src/main/java/org/activiti/designer/kickstart/eclipse/editor/KickstartProcessEditorUpdateBehavior.java
+++ b/org.activiti.designer.kickstart.eclipse/src/main/java/org/activiti/designer/kickstart/eclipse/editor/KickstartProcessEditorUpdateBehavior.java
@@ -33,7 +33,7 @@ public class KickstartProcessEditorUpdateBehavior extends DefaultUpdateBehavior 
   @Override
   public TransactionalEditingDomain getEditingDomain() {
     if (super.getEditingDomain() == null) {
-      createEditingDomain();
+      createEditingDomain(null);
     }
 
     return super.getEditingDomain();

--- a/org.activiti.designer.kickstart.gui.form/src/main/java/org/activiti/designer/kickstart/form/property/AbstractKickstartFormComponentSection.java
+++ b/org.activiti.designer.kickstart.gui.form/src/main/java/org/activiti/designer/kickstart/form/property/AbstractKickstartFormComponentSection.java
@@ -28,6 +28,7 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.graphiti.mm.pictograms.Diagram;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
+import org.eclipse.graphiti.ui.editor.DiagramBehavior;
 import org.eclipse.graphiti.ui.editor.DiagramEditor;
 import org.eclipse.graphiti.ui.platform.GFPropertySection;
 import org.eclipse.swt.SWT;
@@ -241,8 +242,8 @@ public abstract class AbstractKickstartFormComponentSection extends GFPropertySe
   protected void executeModelUpdater() {
     // Make sure the update of the model is done in the transactional editing domain
     // to allow for "undoing" changes
-    DiagramEditor diagramEditor = (DiagramEditor) getDiagramEditor();
-    TransactionalEditingDomain editingDomain = diagramEditor.getEditingDomain();
+	DiagramBehavior diagramBehavior = (DiagramBehavior) getDiagramTypeProvider().getDiagramBehavior();
+    TransactionalEditingDomain editingDomain = diagramBehavior.getEditingDomain();
     
     if(currentUpdater != null) {
       // Do the actual changes to the business-object in a command

--- a/org.activiti.designer.kickstart.gui.process/src/main/java/org/activiti/designer/kickstart/process/property/AbstractKickstartProcessPropertySection.java
+++ b/org.activiti.designer.kickstart.gui.process/src/main/java/org/activiti/designer/kickstart/process/property/AbstractKickstartProcessPropertySection.java
@@ -28,6 +28,7 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.graphiti.mm.pictograms.Diagram;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
+import org.eclipse.graphiti.ui.editor.DiagramBehavior;
 import org.eclipse.graphiti.ui.editor.DiagramEditor;
 import org.eclipse.graphiti.ui.platform.GFPropertySection;
 import org.eclipse.swt.SWT;
@@ -281,8 +282,8 @@ public abstract class AbstractKickstartProcessPropertySection extends GFProperty
   protected void executeModelUpdater() {
     // Make sure the update of the model is done in the transactional editing domain
     // to allow for "undoing" changes
-    DiagramEditor diagramEditor = (DiagramEditor) getDiagramEditor();
-    TransactionalEditingDomain editingDomain = diagramEditor.getEditingDomain();
+	DiagramBehavior diagramBehavior = (DiagramBehavior) getDiagramTypeProvider().getDiagramBehavior();
+    TransactionalEditingDomain editingDomain = diagramBehavior.getEditingDomain();
     
     if(currentUpdater != null) {
       // Do the actual changes to the business-object in a command


### PR DESCRIPTION
Dear developer,

Since I wasn't able to install Activiti Eclipse feature on current Spring Source Tools suite (based on Eclipse Neon), I modified some code to make it compatible. I successfully tested the designer (create an Activiti Project, create new diagram, open existing diagram, edit properties and save diagram).

Hope this help.

Kind Regards,
Alexandre de Pellegrin